### PR TITLE
fix:로그 아웃 시 페이지 함수 수정

### DIFF
--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -1,20 +1,19 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
 import { requestAccessToken } from "../service/api";
-import { usePageRoute } from "./usePageRoute";
 import { apiLogout } from "../service/api/user";
+import { usePageRoute } from "./usePageRoute";
 
 export const useAccount = () => {
   const [isLogined, setIsLogined] = useState(false);
   // TODO: 분리해도될지 고민 필요
-  const { movePage } = usePageRoute();
+  const { goHome } = usePageRoute();
   const handleLogout = async () => {
     // TODO : logout API
     await apiLogout();
     // 토큰 제거
     axios.defaults.headers.common["Authorization"] = undefined;
-    // TODO: cookie 제거도 안됨
-    movePage("/", { replace: true });
+    goHome();
   };
 
   useEffect(() => {


### PR DESCRIPTION
- 로그아웃 후, 실제 라우팅경로로 이동할 경우, 이동 이후에 뒤로 가기 시 다시 기존 페이지로 복구 가능
- 페이지에 대한 예외처리가 맞을수도 있지만,우선은 Home 처리에 대한 일관된 동작을 위해 수정