### PR TITLE
feat: save user info

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 import styled, { CSSProp, css } from "styled-components";
 import { history } from "../..";
-import { decreaseBackToHomePageCount } from "../../hooks/usePageRoute";
 import { ModalType } from "../modals/type";
 
 interface Props {
@@ -17,10 +16,10 @@ export const Modal = ({
   closeModalByUI,
   modalType = 0,
 }: Props) => {
+  // 뒤로가기
   useEffect(() => {
     const event = history.listen((listener) => {
       if (listener.action === "POP") {
-        decreaseBackToHomePageCount();
         closeModalByUI();
       }
     });

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -1,22 +1,13 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
 import { requestAccessToken } from "../service/api";
-import { apiLogout } from "../service/api/user";
-import { usePageRoute } from "./usePageRoute";
+import { apiLogout, getUser } from "../service/api/user";
+import { actionUser } from "../store/user/userSlice";
+import { useAppDispatch } from "./redux";
 
 export const useAccount = () => {
+  const dispatch = useAppDispatch();
   const [isLogined, setIsLogined] = useState(false);
-  // TODO: 분리해도될지 고민 필요
-  const handleLogout = async () => {
-    // TODO : logout API
-    const res = await apiLogout();
-    if (res) {
-      // 토큰 제거
-      axios.defaults.headers.common["Authorization"] = undefined;
-      return true;
-    }
-    return false;
-  };
 
   useEffect(() => {
     console.log("useAcoount useEffect trigger check");
@@ -30,9 +21,38 @@ export const useAccount = () => {
     });
   });
 
+  // TODO: 분리해도될지 고민 필요
+  const handleLogout = async () => {
+    const res = await apiLogout();
+    if (res) {
+      // 토큰 제거
+      axios.defaults.headers.common["Authorization"] = undefined;
+      dispatch(actionUser.resetUserInfo());
+      return true;
+    }
+    return false;
+  };
+
+  const reloadUserInfo = async () => {
+    try {
+      const { userInfo } = await getUser();
+      dispatch(
+        actionUser.setUser({
+          userId: userInfo.userId,
+          nickname: userInfo.nickname,
+          profileImgSrc: userInfo.profileImgSrc,
+        })
+      );
+      return true;
+    } catch (e) {
+      return false;
+    }
+  };
+
   return {
     isLogined,
     handleLogout,
+    reloadUserInfo,
   };
 };
 

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,34 +1,35 @@
 import { useQuery } from "@tanstack/react-query";
-import axios from "axios";
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import Loading from "../../components/Loading";
+import { useAppDispatch } from "../../hooks/redux";
 import { usePageRoute } from "../../hooks/usePageRoute";
-import { BasicUserInfo, apiLogout, getUser } from "../../service/api/user";
+import { BasicUserInfo, getUser } from "../../service/api/user";
+import { actionUser } from "../../store/user/userSlice";
 import { getDisplayMoney } from "../../utils/display";
 import { ActiveGameNotifier } from "./ActiveGameNotifier";
 import { HomeImageButton } from "./HomeImageButton";
 
 export const Home = (props: { handleLogout: () => void }) => {
+  const dispatch = useAppDispatch();
   const { movePage, goHome } = usePageRoute();
-  /**
-   * TODO
-   * - 진입과 동시에 로그인된 유저의 정보를 가져온다. feat axios
-   * - 가져와서 해당정보로 화면에 그려주기
-   */
   const { isLoading, error, data } = useQuery(["userInfo"], () => getUser());
-  const handleLogout = async () => {
-    await apiLogout();
-    axios.defaults.headers.common["Authorization"] = undefined;
-    movePage("/", { replace: true });
-    // if (ret) {
-    //   props.handleLogout();
-    // } else {
-    //   alert("logout error retry it");
-    // }
-  };
+
+  useEffect(() => {
+    if (data) {
+      dispatch(
+        actionUser.setUser({
+          userId: data.userInfo.userId,
+          nickname: data.userInfo.nickname,
+          profileImgSrc: data.userInfo.profileImgSrc,
+        })
+      );
+    }
+  }, [data, dispatch]);
+
   if (isLoading || data === undefined) return <Loading />;
   if (error) return <div>error</div>;
+
   return (
     <Styled.Wrapper>
       <Styled.Top>GOLF BET</Styled.Top>

--- a/src/pages/Setting/Setting.tsx
+++ b/src/pages/Setting/Setting.tsx
@@ -1,21 +1,31 @@
 import styled, { css } from "styled-components";
-import { PageStyle } from "../../styles/page";
-import { usePageRoute } from "../../hooks/usePageRoute";
-import TitleAsset from "../../components/TitleAsset";
-import { typo } from "../../styles/typo";
 import Button from "../../components/Button";
+import TitleAsset from "../../components/TitleAsset";
+import { useAppSelector } from "../../hooks/redux";
+import { usePageRoute } from "../../hooks/usePageRoute";
+import { PageStyle } from "../../styles/page";
+import { typo } from "../../styles/typo";
 
 export const Setting = () => {
+  const userInfo = useAppSelector((state) => state.users.userInfo);
   const { goHome, movePage } = usePageRoute();
+
+  // TODO: userId가 없어졌을때 로직 추가 필요
+  if (!userInfo.userId) goHome();
   return (
     <PageStyle.Wrapper>
       <TitleAsset title="설정" />
       <S.Body>
         <S.ProfileSection>
           <S.UserImg
-            src={process.env.PUBLIC_URL + "/assets/images/profile_test_img.png"}
+            src={userInfo.profileImgSrc}
+            onError={(e) => {
+              (e.target as any).src =
+                process.env.PUBLIC_URL + "/assets/images/profile_test_img.png";
+            }}
+            alt="profile image"
           />
-          <S.UserNickname>Test님</S.UserNickname>
+          <S.UserNickname>{userInfo.nickname}님</S.UserNickname>
           <Button
             variants="info"
             style={{ width: "fit-content", padding: "6px 25px" }}

--- a/src/service/api/constant.ts
+++ b/src/service/api/constant.ts
@@ -15,7 +15,7 @@ export const API_URL = {
   GET_GAME_ROOM_INFO: "",
   CAN_ENTER_GAME_ROOM: "v1/canentergame",
   MAKE_GAME: "v1/make/game",
-};
+} as const;
 
 export const UNIQUE_QUERY_KEY = {
   GET_ALL_GOLF_CENTER: "getAllGolfCenter",

--- a/src/service/api/user.ts
+++ b/src/service/api/user.ts
@@ -4,16 +4,8 @@ import { REACT_APP_KAKAO_REDIRECT } from "../../pages/Login/Login";
 import { testAsync } from "../../utils/test-promise";
 import { API_URL } from "./constant";
 
-export type User = {
-  id: string;
-  imgSrc: string;
-  moneySum: number;
-  fieldGameScore: number;
-  screenGameScore: number;
-  status: null | any;
-};
-
 export type BasicUserInfo = {
+  userId: string;
   nickname: string;
   profileImgSrc: string;
   screenScore: number;
@@ -51,6 +43,7 @@ export const getUser = async () => {
 //   "https://my-json-server.typicode.com/typicode/demo/posts"
 // );
 const mockUserInfo: BasicUserInfo = {
+  userId: "test",
   nickname: "TEST",
   profileImgSrc: process.env.PUBLIC_URL + "/assets/images/profile_test_img.png",
   screenScore: 99,

--- a/src/store/user/userSlice.ts
+++ b/src/store/user/userSlice.ts
@@ -2,13 +2,22 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { RootState } from "..";
 
 // Define a type for the slice state
+export type UserSliceInfo = {
+  userId: string;
+  nickname: string;
+  profileImgSrc: string;
+};
 export interface UserState {
-  userInfo: number;
+  userInfo: UserSliceInfo;
 }
 
 // Define the initial state using that type
 const initialState: UserState = {
-  userInfo: 0,
+  userInfo: {
+    userId: "",
+    nickname: "",
+    profileImgSrc: "",
+  },
 };
 
 export const userSlice = createSlice({
@@ -16,8 +25,11 @@ export const userSlice = createSlice({
   // `createSlice` will infer the state type from the `initialState` argument
   initialState,
   reducers: {
+    resetUserInfo: (state) => {
+      state.userInfo = initialState.userInfo;
+    },
     // Use the PayloadAction type to declare the contents of `action.payload`
-    setUser: (state, action: PayloadAction<any>) => {
+    setUser: (state, action: PayloadAction<UserSliceInfo>) => {
       state.userInfo = action.payload;
     },
   },


### PR DESCRIPTION
- modal이 닫힐 경우에 , Home 으로 가는 Page count 를 조절하는 부분이 있는데, 현재 뒤로가기를 통해 modal을 닫을 떄 그 부분이 2번 실행되게 되어있어서 수정
- Home에서 user 정보 업데이트 시에, store에 저장 및 로그아웃시 초기화 구현