### PR TITLE
feat: 점수 확정 fix hole score

### DIFF
--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -1,11 +1,14 @@
 import styled from "styled-components";
 
-export const Loading = () => {
+export const Loading = ({ onTest }: any) => {
   return (
     <S.PageBackground>
       <S.Background>
         <S.Body>
-          <S.Img src={process.env.PUBLIC_URL + "/assets/gif/loading.gif"} />
+          <S.Img
+            src={process.env.PUBLIC_URL + "/assets/gif/loading.gif"}
+            onClick={onTest}
+          />
         </S.Body>
       </S.Background>
     </S.PageBackground>

--- a/src/components/ModalContainer/ModalContainer.tsx
+++ b/src/components/ModalContainer/ModalContainer.tsx
@@ -83,7 +83,7 @@ const modalChildrenSelector = (
       );
     case "VIEW_RULE":
       return <ViewRule gameRoomInfo={modalParam.args.gameRoomInfo} />;
-    case "DECLARE_DDANG_PARAM":
+    case "DECLARE_DDANG":
       return (
         <DeclareDdang
           lastPlayers={modalParam.args.lastPlayers}

--- a/src/components/modals/type.ts
+++ b/src/components/modals/type.ts
@@ -65,7 +65,7 @@ type ConfirmParam = {
   };
 };
 type DeclareDdangParam = {
-  id: "DECLARE_DDANG_PARAM";
+  id: "DECLARE_DDANG";
   args: DeclareDdangProps;
 };
 
@@ -147,7 +147,7 @@ export const getModalTypeById = (id: ModalParam["id"]) => {
     case "SELECT_NEAR_LONG":
       return MODAL_TYPE.BOTTOM_SHEET;
 
-    case "DECLARE_DDANG_PARAM":
+    case "DECLARE_DDANG":
       return MODAL_TYPE.BACKGROUND_CNETER;
 
     default:

--- a/src/pages/GameRoom/GameRoom.tsx
+++ b/src/pages/GameRoom/GameRoom.tsx
@@ -119,7 +119,7 @@ export const GameRoom = () => {
 
   // 3 웹 소켓 연결
   if (socket.connected === false || gameRoomInfo === undefined)
-    return <Loading />;
+    return <Loading onTest={handleExitInGame} />;
   // 대기실
   if (gameRoomInfo.gameInfo.gameState === GAME_STATE.WAIT)
     return (

--- a/src/pages/GameRoom/InGame/DeclareDdang/DelcareDdang.tsx
+++ b/src/pages/GameRoom/InGame/DeclareDdang/DelcareDdang.tsx
@@ -3,7 +3,8 @@ import Button from "../../../../components/Button";
 import { GameRoomUser } from "../../GameRoom";
 
 export type DeclareDdangProps = {
-  handleModalResult?: (result: boolean) => void;
+  // 뒤로가기가 false 를 반환해서 아니오를 누른 것과 뒤로가기를 누른 것을 구분하기 위해서  'yes' | 'no' 를 씀
+  handleModalResult?: (result: "yes" | "no") => void;
   lastPlayers: GameRoomUser[];
 };
 
@@ -31,11 +32,11 @@ export const DeclareDdang = ({
       </S.Body>
       <S.HorizontalSeperator />
       <S.Footer>
-        <S.ModalBtn onClick={() => handleModalResult?.(false)}>
+        <S.ModalBtn onClick={() => handleModalResult?.("no")}>
           <span className="confirm__cancel">아니요</span>
         </S.ModalBtn>
         <S.VerticalSeperator />
-        <S.ModalBtn onClick={() => handleModalResult?.(true)}>
+        <S.ModalBtn onClick={() => handleModalResult?.("yes")}>
           땅선언
         </S.ModalBtn>
       </S.Footer>

--- a/src/pages/GameRoom/InGame/EnterHoleScore/EnterHoleScore.tsx
+++ b/src/pages/GameRoom/InGame/EnterHoleScore/EnterHoleScore.tsx
@@ -115,7 +115,7 @@ export const EnterHoleScore = ({ handleModalResult }: EnterHoleScoreProps) => {
           playerScores,
           holeInfo: {
             players,
-            ddang: res.ddang,
+            ddang: false, // 일단 default return
             doubleConditions: res.doubleConditions,
             hole: currentHole,
             par: currentPar,

--- a/src/pages/GameRoom/InGame/EnterHoleScore/EnterHoleScore.tsx
+++ b/src/pages/GameRoom/InGame/EnterHoleScore/EnterHoleScore.tsx
@@ -21,7 +21,7 @@ export type EnterScoreResult = {
   isAllEnter: boolean;
   /** type PlayerScores = Record<string, number>; */
   playerScores: PlayerScores;
-  holeInfo: InGameInfo["holeInfos"][number] | null;
+  holeInfo?: InGameInfo["holeInfos"][number];
 };
 type PlayerScores = Record<string, number>;
 
@@ -83,6 +83,7 @@ export const EnterHoleScore = ({ handleModalResult }: EnterHoleScoreProps) => {
 
     // 점수 다입력되었으니 확정으로
     if (isAllPlayerScoreEntered) {
+      // TODO : 여기서 입력제어
       const res = await openModal<FixHoleScoreResult>({
         id: "FIX_HOLE_SCORE",
         args: {
@@ -95,15 +96,18 @@ export const EnterHoleScore = ({ handleModalResult }: EnterHoleScoreProps) => {
         // TODO: Ingame 정보 받아와서 이전홀 정보 확인해야 함
         const players: InGameInfo["holeInfos"][number]["players"] = {};
         Object.entries(playerScores).forEach(([userId, score]) => {
+          // 현재홀 idx = 현재홀 - 1,로 이전홀의 idx = 현재홀 - 2
+          const previousHoleIndex = currentHole - 2;
+          // 1홀(이전 홀 idx = -1) 일때 는 베팅 준비금,
+          const previousMoney =
+            previousHoleIndex < 0
+              ? gameRoomInfo.gameInfo.bettingLimit
+              : inGameInfo[previousHoleIndex]?.players[userId].remainingMoney;
           players[userId] = {
             strokes: score,
             moneyChange: res.playersMoneyChange[userId],
-            previousMoney:
-              inGameInfo[currentHole]?.players[userId].remainingMoney ??
-              gameRoomInfo.gameInfo.bettingLimit,
-            remainingMoney:
-              gameRoomInfo.gameInfo.bettingLimit +
-              res.playersMoneyChange[userId],
+            previousMoney,
+            remainingMoney: previousMoney + res.playersMoneyChange[userId],
           };
         });
         handleModalResult?.({
@@ -111,8 +115,8 @@ export const EnterHoleScore = ({ handleModalResult }: EnterHoleScoreProps) => {
           playerScores,
           holeInfo: {
             players,
-            doubleConditions: [],
             ddang: res.ddang,
+            doubleConditions: res.doubleConditions,
             hole: currentHole,
             par: currentPar,
           },
@@ -125,7 +129,6 @@ export const EnterHoleScore = ({ handleModalResult }: EnterHoleScoreProps) => {
       handleModalResult?.({
         isAllEnter: false,
         playerScores,
-        holeInfo: null,
       });
     }
   };

--- a/src/pages/GameRoom/InGame/FixHoleScore/FixHoleScore.tsx
+++ b/src/pages/GameRoom/InGame/FixHoleScore/FixHoleScore.tsx
@@ -26,10 +26,6 @@ export type FixHoleScoreResult = {
    * 니어리스트 , 롱기스트 선택 유저 id
    */
   nearLong: string[];
-  /**
-   * 땅 적용 여부
-   */
-  ddang: boolean;
   doubleConditions: string[];
   playersMoneyChange: Record<string, number>;
 };
@@ -106,33 +102,12 @@ export const FixHoleScore = ({
       // 니어,롱기 선택창에서 취소를 눌럿다면 땅 진행이 아니고 진행 취소
       if (nearLongRes === false) return;
     }
-    // #2 땅 확인
-    let isDdangDeclare = false;
-    const [ddangRuleValue] = ddang;
-    if (ddangRuleValue === "onlyLastPlace") {
-      // 꼴등 식별
-      const lastRankPlayers: GameRoomUser[] = [];
-      findLastRankPlayer(playerScores).forEach((userId) => {
-        players.forEach((player) => {
-          if (player.userId === userId) {
-            lastRankPlayers.push(player);
-          }
-        });
-      });
-      // 모달 오픈
-      isDdangDeclare = await openModal({
-        id: "DECLARE_DDANG_PARAM",
-        args: {
-          lastPlayers: lastRankPlayers,
-        },
-      });
-    }
     handleModalResult?.({
       nearLong,
       doubleConditions,
       playersMoneyChange,
       result: true,
-      ddang: isDdangDeclare,
+      // ddang: isDdangDeclare,
     });
   };
 

--- a/src/pages/GameRoom/InGame/FixHoleScore/FixHoleScore.tsx
+++ b/src/pages/GameRoom/InGame/FixHoleScore/FixHoleScore.tsx
@@ -30,6 +30,7 @@ export type FixHoleScoreResult = {
    * 땅 적용 여부
    */
   ddang: boolean;
+  doubleConditions: string[];
   playersMoneyChange: Record<string, number>;
 };
 
@@ -127,10 +128,11 @@ export const FixHoleScore = ({
       });
     }
     handleModalResult?.({
-      result: true,
       nearLong,
-      ddang: isDdangDeclare,
+      doubleConditions,
       playersMoneyChange,
+      result: true,
+      ddang: isDdangDeclare,
     });
   };
 

--- a/src/pages/GameRoom/InGame/InGame.tsx
+++ b/src/pages/GameRoom/InGame/InGame.tsx
@@ -62,6 +62,7 @@ export const InGame = ({
   });
   const { gameInfo, players } = gameRoomInfo;
   const {
+    gameId,
     gameType: centerType,
     golfCenter: centerInfo,
     betType,
@@ -85,11 +86,10 @@ export const InGame = ({
       return;
     }
     if (res.isAllEnter) {
-      // const holeInfo: InGameInfo["holeInfos"][number] = {
-      //   ddang: false,
-      // };
-      console.log("TODO : InGame - 점수 확정", res);
-      // fixScore();
+      if (gameId && res.holeInfo) {
+        // 점수 확정
+        fixScore(gameId, userInfo.userId, res.holeInfo);
+      }
     }
     if (res.isAllEnter === false) {
       enterScore(gameRoomInfo.gameInfo.gameId, currentHole, res);

--- a/src/service/socketIo/socketIo.context.tsx
+++ b/src/service/socketIo/socketIo.context.tsx
@@ -259,7 +259,9 @@ function SocketsProvider(props: any) {
     userId: string,
     holeInfo: InGameInfo["holeInfos"][number]
   ) => {
-    console.log(`FixScore gameId : ${gameId}, 입력홀정보: ${holeInfo}`);
+    console.log(
+      `FixScore gameId : ${gameId}, 입력홀정보: ${JSON.stringify(holeInfo)}`
+    );
     socket.emit(EVENTS.TO_SERVER.SEND_TASK_MESSAGE, {
       taskName: TASK.FIX_SCORE,
       data: {


### PR DESCRIPTION
- test: 임시 게임 복귀 중 무한 로딩때 로딩 아이콘 클릭시 방나가기

- 이전 홀 보유량 처리 및 index 오류로 수정
- socket 다음홀 작업 추가 (task : next)

- 니어리스트 이후 다 닫고, 땅 팝업 작동하게 방식 변경
  -> 땅 팝업에서 취소 누를 경우 기존에는 다음홀 처리 되었으나 취소 시, 미입력전으로 갈 수 있음
- TODO : 땅팝업 리턴 타입 관련 수정 필요