### PR TITLE
feat : 점수 확정시에 백에서 입력제어 해제 추가하여, front에서 제거

### DIFF
--- a/src/pages/GameRoom/InGame/InGame.tsx
+++ b/src/pages/GameRoom/InGame/InGame.tsx
@@ -175,7 +175,6 @@ export const InGame = ({
         }
         // 점수 확정
         finalizeScore(gameId, userInfo.userId, res.holeInfo, res.surrenders);
-        setCanEnterScore(gameId, "");
       }
     }
     if (res.isAllEnter === false) {
@@ -196,7 +195,6 @@ export const InGame = ({
       return;
     }
     modifyScore(gameId, userInfo.userId, res.holeInfo);
-    setCanEnterScore(gameId, "");
   };
   return (
     <PageStyle.Wrapper>


### PR DESCRIPTION
기존 프론트에서 작업 

소켓 전달 메세지 작업 연속으로 2번 전달 -> 1번으로 변경
- 점수 확정
- 점수 입력 제한 해제 

-> 점수 확정 시에 백에서 입력 제한 해제 값 까지 한번에 변경 