### PR TITLE
fix: 점수 확정시 기권자 점수 처리

### DIFF
--- a/src/pages/GameRoom/InGame/EnterHoleScore/EnterHoleScore.tsx
+++ b/src/pages/GameRoom/InGame/EnterHoleScore/EnterHoleScore.tsx
@@ -190,7 +190,7 @@ export const EnterHoleScore = ({ handleModalResult }: EnterHoleScoreProps) => {
               ? bettingLimit
               : holeInfos?.[previousHoleIndex]?.players[userId].remainingMoney;
           players[userId] = {
-            strokes: score,
+            strokes: score === UNENTERED_HOLE_SCORE ? 0 : score,
             moneyChange: res.playersMoneyChange[userId] ?? 0,
             previousMoney,
             remainingMoney:


### PR DESCRIPTION
- 기권자의 경우 999로 처리되어있는 값이 그래도 넘어가고 있어, 기권자의 경우 score를 0 으로 처리