### PR TITLE
fix: 진행 현황 탭, 후반 ui 클릭시 전반 클릭 되던 현상 수정

### DIFF
--- a/src/pages/GameRoom/InGame/ProgressTab/ProgressBoard/ParBlock.tsx
+++ b/src/pages/GameRoom/InGame/ProgressTab/ProgressBoard/ParBlock.tsx
@@ -27,7 +27,7 @@ export const ParBlock = ({
         if (status !== STATUS.NOT_STARTED) handleHoleClick(hole);
       }}
     >
-      <span className="parblock__holeindex">{hole}H</span>
+      <span className="parblock__holeindex">{hole > 9 ? hole - 9 : hole}H</span>
       <span className="parblock__parcount">{parCount}파</span>
     </S.Wrapper>
   );

--- a/src/pages/GameRoom/InGame/ProgressTab/ProgressBoard/ProgressBoard.tsx
+++ b/src/pages/GameRoom/InGame/ProgressTab/ProgressBoard/ProgressBoard.tsx
@@ -35,7 +35,7 @@ export const ProgressBoard = ({
         return (
           <ParBlock
             key={`${index + 1}`}
-            hole={index + 1}
+            hole={index + 1 + 9}
             parCount={par}
             status={getHoleStatus(index + 1 + 9, currentHole, selectHole)}
             handleHoleClick={handleHoleClick}


### PR DESCRIPTION
- 후반 홀을 클릭해도 전반 홀로 처리되던 버그 수정 